### PR TITLE
外付けの AD コンバータ MCP3002 を使う

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,4 +16,6 @@ upload_port = /dev/tty.usbserial-DM02NA6M
 monitor_port = /dev/tty.usbserial-DM02NA6M
 monitor_speed = 74880
 monitor_filters = esp8266_exception_decoder
-lib_deps = ambientdatainc/Ambient ESP32 ESP8266 lib@^1.0.1
+lib_deps = 
+	ambientdatainc/Ambient ESP32 ESP8266 lib@^1.0.1
+	bakercp/MCP3XXX@^1.0.0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,6 @@ const int PUMP_PIN = 4; // IO4
 
 WiFiClient client;
 Ambient ambient;
-MCP3002 adc;
 
 /* deep sleep して終了。wake 時には setup から始まる */
 void deepSleep()
@@ -35,9 +34,12 @@ void setupWiFi()
 
 float getMoisture()
 {
-  const int vAir = 397;   // 空気中での測定値
-  const int vWater = 225; // 水中での測定値
-  return 100.0 * (vAir - analogRead(A0)) / (vAir - vWater);
+  const int vAir = 725;   // 空気中での測定値
+  const int vWater = 317; // 水中での測定値
+
+  MCP3002 adc;
+  adc.begin(5); // SPI の CS ピンとして IO5 を使う
+  return 100.0 * (vAir - adc.analogRead(0)) / (vAir - vWater);
 }
 
 void setup()
@@ -45,9 +47,6 @@ void setup()
   Serial.begin(74880);
   pinMode(PUMP_PIN, OUTPUT);
   setupWiFi();
-
-  adc.begin(5); // SPI の CS ピンとして IO5 を使う
-  return;
 
   const float moisture = getMoisture();
   Serial.println(moisture);
@@ -64,8 +63,4 @@ void setup()
   deepSleep();
 }
 
-void loop()
-{
-  Serial.println(adc.analogRead(0));
-  delay(200);
-}
+void loop() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ Ambient ambient;
 /* deep sleep して終了。wake 時には setup から始まる */
 void deepSleep()
 {
-  const int intervalMinutes = 10;
+  const int intervalMinutes = 20;
   ESP.deepSleep(intervalMinutes * 60 * 1000 * 1000, WAKE_RF_DEFAULT);
   delay(1000); // deep sleep が始まるまで待つ
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,14 @@
 #include <Arduino.h>
 #include <ESP8266WiFi.h>
-#include "Ambient.h"
+#include <Ambient.h>
+#include <MCP3XXX.h>
 #include "secrets.h"
 
 const int PUMP_PIN = 4; // IO4
 
 WiFiClient client;
 Ambient ambient;
+MCP3002 adc;
 
 /* deep sleep して終了。wake 時には setup から始まる */
 void deepSleep()
@@ -44,6 +46,9 @@ void setup()
   pinMode(PUMP_PIN, OUTPUT);
   setupWiFi();
 
+  adc.begin(5); // SPI の CS ピンとして IO5 を使う
+  return;
+
   const float moisture = getMoisture();
   Serial.println(moisture);
 
@@ -59,4 +64,8 @@ void setup()
   deepSleep();
 }
 
-void loop() {}
+void loop()
+{
+  Serial.println(adc.analogRead(0));
+  delay(200);
+}


### PR DESCRIPTION
#5 で書いたように、ESP8266 のアナログ入力は 1 つしかないので、電源電圧と水分量センサーの値を同時に取得することはできない。

そこで、10bit 2ch の AD コンバータ MCP3002 を外付けし、水分量センサーの値を読み取ることにする。MCP3002 は[秋月で160円](https://akizukidenshi.com/catalog/g/gI-02584/)で購入できる。

## MCP3002 の接続

[MCP3002 のデータシート](https://akizukidenshi.com/download/ds/microchip/mcp3002.pdf)によると、以下のようなピン配置になっている。

<img width="277" alt="MCP3002_2_7V_Dual_Channel_10-Bit_A_D_Converter_with_SPI_Serial_Interface_-_mcp3002_pdf" src="https://user-images.githubusercontent.com/6268183/122420658-ce818100-cfc6-11eb-8115-2e06709aeb25.png">

1. CS': SPI の SS
1. CH0: チャンネル 0 の入力
1. CH1: チャンネル 1 の入力
1. V<sub>SS</sub>: GND（この電圧が `0` の基準になる）
1. D<sub>IN</sub>: SPI の MOSI
1. D<sub>OUT</sub>: SPI の MISO
1. CLK: SPI の SCLK
1. V<sub>DD</sub>: 電源（この電圧が `1023` の基準になる）

一方の ESP-WROOM-02 は、SPI 関連のデフォルトのピンアサインが決まっているが、SS だけは IO15 から変更した方がいいらしい。

- [ESP8266でSPI通信する - Qiita](https://qiita.com/hikoalpha/items/f735662e2e0d75699675#%E9%85%8D%E7%B7%9A)

ということで、以下のように接続した。

|MCP3002|ESP-WROOM-02|機能|
|--|--|--|
|1. CS' | IO5 | SPI の SS |
|2. CH0 | - | チャンネル 0 の入力 |
|3. CH1 | - | チャンネル 1 の入力 |
|4. V<sub>SS</sub> | (GND) | GND |
|5. D<sub>IN</sub> | IO13 | SPI の MOSI |
|6. D<sub>OUT</sub> | IO12 | SPI の MISO |
|7. CLK | IO14 | SPI の SCLK |
|8. V<sub>DD</sub> | (3V3) | 電源 |