### PR TITLE
ESP-WROOM-02 の電源電圧を測定する

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,9 +6,6 @@
 
 ADC_MODE(ADC_VCC);
 
-WiFiClient client;
-Ambient ambient;
-
 /* deep sleep して終了。wake 時には setup から始まる */
 void deepSleep()
 {
@@ -62,15 +59,12 @@ void setup()
   const auto vcc = ESP.getVcc() / 1000.0;
   Serial.printf("Vcc: %5.3fV\n", vcc);
 
+  Ambient ambient;
+  WiFiClient client;
   ambient.begin(AMBIENT_CHANNEL_ID, AMBIENT_WRITE_KEY, &client);
   ambient.set(1, moisture);
   ambient.set(2, vcc);
   ambient.send();
-
-  // digitalWrite(PUMP_PIN, HIGH);
-  // delay(5000);
-  // digitalWrite(PUMP_PIN, LOW);
-  // delay(5000);
 
   deepSleep();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,8 @@
 #include <MCP3XXX.h>
 #include "secrets.h"
 
+ADC_MODE(ADC_VCC);
+
 WiFiClient client;
 Ambient ambient;
 
@@ -55,11 +57,14 @@ void setup()
   Serial.begin(74880);
   setupWiFi();
 
-  const float moisture = getMoisture();
-  Serial.println(moisture);
+  const auto moisture = getMoisture();
+  Serial.printf("Moisture: %5.2f%%\n", moisture);
+  const auto vcc = ESP.getVcc() / 1000.0;
+  Serial.printf("Vcc: %5.3fV\n", vcc);
 
   ambient.begin(AMBIENT_CHANNEL_ID, AMBIENT_WRITE_KEY, &client);
   ambient.set(1, moisture);
+  ambient.set(2, vcc);
   ambient.send();
 
   // digitalWrite(PUMP_PIN, HIGH);


### PR DESCRIPTION
Close #5

土壌水分量の測定は、#6 で外付け AD コンバータを使うようにした。そのため、ESP8266 内蔵の機能で、電源電圧が測定できるようになった。これを使って電源電圧を測定し、Ambient に送信する。